### PR TITLE
Includes shims

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 /* eslint-disable filenames/match-exported */
+
+const padEnd = require('string.prototype.padend');
+const padStart = require('string.prototype.padstart');
 const TapReporter = require('./src/TapReporter');
+
+padEnd.shim();
+padStart.shim();
 
 module.exports = TapReporter;

--- a/package.json
+++ b/package.json
@@ -38,17 +38,22 @@
       "index.js"
     ],
     "reporters": [
-      ["./", {
-        "logLevel": "INFO",
-        "showInternalStackTraces": false
-      }]
+      [
+        "./",
+        {
+          "logLevel": "INFO",
+          "showInternalStackTraces": false
+        }
+      ]
     ],
     "testRegex": "(test|src)\\/.+\\.(test|spec)\\.jsx?$"
   },
   "dependencies": {
+    "@babel/code-frame": "7.0.0-beta.34",
     "chalk": "^2.3.0",
+    "string.prototype.padend": "^3.0.0",
+    "string.prototype.padstart": "^3.0.0",
     "strip-ansi": "4.0.0",
-    "utf8-bar": "0.1.0",
-    "@babel/code-frame": "7.0.0-beta.34"
+    "utf8-bar": "0.1.0"
   }
 }


### PR DESCRIPTION
Includes the shims for the environments that don't have padStart and padEnd on String.prototype

Fixes #17 