### PR TITLE
add support to log to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ You can add an optional configuration object:
   "reporters": [
     ["jest-tap-reporter", {
       "logLevel": "ERROR",
-      "showInternalStackTraces": true
+      "showInternalStackTraces": true,
+      "filePath": "filename.tap"
     }]
   ]
 }
@@ -63,6 +64,7 @@ Options:
 
   - `logLevel` - specifies the log level. By default jest-tap-reporter uses `INFO` log level, which will log the suite path and a summary at the end of a test run. If you want to reduce the reporting to bare minimum you can set the `logLevel` parameter to `ERROR`. available log levels are: `ERROR`, `WARN`, `INFO`.
   - `showInternalStackTraces` - shows stack traces from *"internal"* folders, like `/node_modules` and `/internal`, defaults to `false`.
+  - `filePath` - specifies a file to write the results. If not supplied it will use `stdout`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "reporters": [
       ["./", {
         "logLevel": "INFO",
-        "showInternalStackTraces": false
+        "showInternalStackTraces": false,
+        "filePath": "test.tap"
       }]
     ],
     "testRegex": "(test|src)\\/.+\\.(test|spec)\\.jsx?$"

--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -1,4 +1,5 @@
 /* eslint-disable id-match, class-methods-use-this, no-console */
+const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 const LoggerTemporal = require('./loggers/LoggerTemporal');
@@ -13,7 +14,17 @@ const sShouldFail = Symbol('shouldFail');
 class TapReporter {
   constructor (globalConfig = {}, options = {}) {
     const {logLevel = 'INFO'} = options;
-    const logger = new LoggerTemporal({logLevel});
+    let stream = process.stdout;
+
+    if (options.filePath) {
+      stream = fs.createWriteStream(options.filePath);
+      chalk.level = 0;
+    }
+
+    const logger = new LoggerTemporal({
+      logLevel,
+      stream
+    });
 
     this.globalConfig = globalConfig;
     this.options = options;


### PR DESCRIPTION
Add support for options to accept `filePath` and use it instead of `process.stdout`