### PR TITLE
Remove hashes from test comments

### DIFF
--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -84,7 +84,7 @@ class TapReporter {
       chalk`{red ${title}}` :
       chalk`{rgb(80,80,80) ${title}}`;
 
-    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ');
+    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ').replace('#', '';
 
     switch (status) {
     case STATUS_PASSED:

--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -84,7 +84,7 @@ class TapReporter {
       chalk`{red ${title}}` :
       chalk`{rgb(80,80,80) ${title}}`;
 
-    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ').replace('#', '';
+    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ').replace('#', '');
 
     switch (status) {
     case STATUS_PASSED:


### PR DESCRIPTION
According to the TAP specification, 

> Any text after the test number but before a # is the description of the test point.

This was not enforced by your reporter and could therefore mess up parsers.