### PR TITLE
Remove hashes from comments

### DIFF
--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -84,7 +84,7 @@ class TapReporter {
       chalk`{red ${title}}` :
       chalk`{rgb(80,80,80) ${title}}`;
 
-    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ');
+    formattedTitle = [...ancestorTitles, formattedTitle].join(' › ').replace('#', '');
 
     switch (status) {
     case STATUS_PASSED:


### PR DESCRIPTION
Sorry for the last pull request, I ended up mangling my repo.

According to the specification:

> Any text after the test number but before a # is the description of the test point.

This rule is currently not enforced and can throw off TAP parsers.