### PR TITLE
Create the containing directory for the output file

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.36",
     "chalk": "^2.3.0",
+    "mkdirp": "0.5.1",
     "string.prototype.padend": "^3.0.0",
     "string.prototype.padstart": "^3.0.0",
     "strip-ansi": "4.0.0",

--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -80,8 +80,8 @@ class TapReporter {
     this.writer.errors(errors, this.options.showInternalStackTraces);
   }
 
-  onAssertionResult (assertiontResult, isLast) {
-    const {ancestorTitles = [], failureMessages, title, status} = assertiontResult;
+  onAssertionResult (assertionResult, isLast) {
+    const {ancestorTitles = [], failureMessages, title, status} = assertionResult;
 
     let formattedTitle = status === STATUS_FAILED ?
       chalk`{red ${title}}` :

--- a/src/TapReporter.js
+++ b/src/TapReporter.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
+const mkdirp = require('mkdirp');
 const LoggerTemporal = require('./loggers/LoggerTemporal');
 const LineWriter = require('./LineWriter');
 
@@ -62,6 +63,8 @@ class TapReporter {
     if (filePath) {
       const {rootDir} = this.globalConfig;
       const filename = path.isAbsolute(filePath) ? filePath : path.join(rootDir, filePath);
+
+      mkdirp(path.dirname(filename));
 
       return fs.createWriteStream(filename);
     } else {


### PR DESCRIPTION
If the output file is specified in a non-existent directory, you will get an error. Remove this error by creating the necessary directory structure before opening the file.